### PR TITLE
Added assert_coderef and assert_empty.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -7,6 +7,7 @@ README.md
 t/00-load.t
 t/assert_coderef.t
 t/assert_defined.t
+t/assert_empty.t
 t/assert_exists.t
 t/assert_fail.t
 t/assert_hashref.t

--- a/MANIFEST
+++ b/MANIFEST
@@ -5,6 +5,7 @@ Makefile.PL
 More.pm
 README.md
 t/00-load.t
+t/assert_coderef.t
 t/assert_defined.t
 t/assert_exists.t
 t/assert_fail.t

--- a/More.pm
+++ b/More.pm
@@ -24,6 +24,7 @@ BEGIN {
     $VERSION = '1.14';
     @ISA = qw(Exporter);
     @EXPORT = qw(
+    	assert_coderef
         assert_defined
         assert_exists
         assert_fail
@@ -542,6 +543,19 @@ sub assert_listref($;$) {
     my $name = shift;
 
     return assert_isa( $ref, 'ARRAY', $name );
+}
+
+=head2 assert_coderef( $ref [,$name] )
+
+Asserts that I<$ref> is defined, and is a reference to a closure.
+
+=cut
+
+sub assert_coderef($;$) {
+    my $ref = shift;
+    my $name = shift;
+
+    return assert_isa( $ref, 'CODE', $name );
 }
 
 =head1 SET AND HASH MEMBERSHIP

--- a/More.pm
+++ b/More.pm
@@ -26,6 +26,7 @@ BEGIN {
     @EXPORT = qw(
     	assert_coderef
         assert_defined
+        assert_empty
         assert_exists
         assert_fail
         assert_hashref
@@ -438,6 +439,50 @@ sub assert_isa($$;$) {
     &Carp::confess( _fail_msg($name) );
 }
 
+
+=head2 assert_empty( $this [, $name ] )
+
+I<$this> must be a ref to either a hash or an array.  Asserts that that
+collection contains no elements.  Will assert (with its own message,
+not I<$name>) unless given a hash or array ref.   It is OK if I<$this> has
+been blessed into objecthood, but the semantics of checking an object to see
+if it does not have keys (for a hashref) or returns 0 in scalar context (for
+an array ref) may not be what you want.
+
+    assert_empty( 0 );       # FAIL
+    assert_empty( 'foo' );   # FAIL
+    assert_empty( undef );   # FAIL
+    assert_empty( {} );      # pass
+    assert_empty( [] );      # pass
+    assert_empty( {foo=>1} );# FAIL
+    assert_empty( [1,2,3] ); # FAIL
+
+=cut
+
+sub assert_empty($;$) {
+    my $ref = shift;
+    my $name = shift;
+
+    require Scalar::Util;
+
+    my $underlying_type;
+    if ( Scalar::Util::blessed( $ref ) ) {
+        $underlying_type = Scalar::Util::reftype( $ref );
+    }
+    else {
+        $underlying_type = ref( $ref );
+    }
+
+    if ( $underlying_type eq 'HASH' ) {
+        assert_is( scalar keys %{$ref}, 0, $name );
+    }
+    elsif ( $underlying_type eq 'ARRAY' ) {
+        assert_is( scalar @{$ref}, 0, $name );
+    }
+    else {
+        assert_fail( 'Not an array or hash reference' );
+    }
+}
 
 =head2 assert_nonempty( $this [, $name ] )
 

--- a/t/assert_coderef.t
+++ b/t/assert_coderef.t
@@ -1,0 +1,61 @@
+#!perl -Tw
+
+package Foo;
+
+sub new { my $class = shift; return bless sub {}, $class; }
+
+package main;
+
+use warnings;
+use strict;
+
+use Test::More tests => 7;
+
+use Carp::Assert::More;
+
+local $@;
+$@ = '';
+
+# {} is not a coderef
+eval {
+    assert_coderef( {} );
+};
+like( $@, qr/Assertion.*failed/ );
+
+# a ref to a hash with stuff in it is not a coderef
+my $ref = { foo => 'foo', bar => 'bar' };
+eval {
+    assert_coderef( $ref );
+};
+like( $@, qr/Assertion.*failed/ );
+
+# 3 is not a coderef
+eval {
+    assert_coderef( 3 );
+};
+like( $@, qr/Assertion.*failed/ );
+
+# [] is not a coderef
+eval {
+    assert_coderef( [] );
+};
+like( $@, qr/Assertion.*failed/ );
+
+# a ref to a list with stuff in it is not a coderef
+my @ary = ('foo', 'bar', 'baaz');
+eval {
+    assert_coderef( \@ary );
+};
+like( $@, qr/Assertion.*failed/ );
+
+# sub {} is a coderef
+eval {
+    assert_coderef( sub {} );
+};
+is( $@, '' );
+
+# Foo->new->isa("CODE") returns true, so do we
+eval {
+    assert_coderef( Foo->new );
+};
+is( $@, '' );

--- a/t/assert_empty.t
+++ b/t/assert_empty.t
@@ -1,0 +1,54 @@
+#!perl -Tw
+
+use warnings;
+use strict;
+
+use Test::More tests => 12;
+use Test::Exception;
+
+use Carp::Assert::More;
+
+use constant PASS => 1;
+use constant FAIL => 0;
+
+my @cases = (
+    [ 0         => FAIL ],
+    [ 'foo'     => FAIL ],
+    [ undef     => FAIL ],
+    [ {}        => PASS ],
+    [ []        => PASS ],
+    [ {foo=>1}  => FAIL ],
+    [ [1,2,3]   => FAIL ],
+);
+
+for my $case ( @cases ) {
+    my ($val,$expected_status) = @$case;
+
+    eval { assert_empty( $val ) };
+    $val = "undef" if !defined($val);
+    my $desc = "Checking \"$val\"";
+
+    if ( $expected_status eq FAIL ) {
+        like( $@, qr/Assertion.+failed/, $desc );
+    } else {
+        is( $@, "", $desc );
+    }
+}
+
+throws_ok( sub { assert_empty( 27 ) }, qr/Not an array or hash reference/ );
+
+BLESSED_ARRAY: {
+    my $array_object = bless( [], 'WackyPackage' );
+    lives_ok( sub { assert_empty( $array_object ) } );
+
+    push( @{$array_object}, 14 );
+    throws_ok( sub { assert_empty( $array_object, 'Flooble' ) }, qr/\QAssertion (Flooble) failed!/ );
+}
+
+BLESSED_HASH: {
+    my $hash_object = bless( {}, 'WackyPackage' );
+    lives_ok( sub { assert_empty( $hash_object ) } );
+
+    $hash_object->{foo} = 14;
+    throws_ok( sub { assert_empty( $hash_object, 'Flargle' ) }, qr/\QAssertion (Flargle) failed!/ );
+}

--- a/t/test-coverage.t
+++ b/t/test-coverage.t
@@ -1,6 +1,6 @@
 #!perl -Tw
 
-use Test::More tests => 26;
+use Test::More tests => 27;
 
 use Carp::Assert::More;
 

--- a/t/test-coverage.t
+++ b/t/test-coverage.t
@@ -1,6 +1,6 @@
 #!perl -Tw
 
-use Test::More tests => 27;
+use Test::More tests => 28;
 
 use Carp::Assert::More;
 


### PR DESCRIPTION
Noticed that this was lacking and thought it would be useful.  I wasn't 100% sure that the caveat applied here, so you might want to check that and adjust if necessary before releasing.

-Eric